### PR TITLE
IHS-19694 salesforce_bulk gem completely disables SSL verify mode

### DIFF
--- a/lib/salesforce_bulk.rb
+++ b/lib/salesforce_bulk.rb
@@ -9,7 +9,7 @@ module SalesforceBulk
   # Your code goes here...
   class Api
 
-    SALESFORCE_API_VERSION = '24.0'.freeze
+    SALESFORCE_API_VERSION = '47.0'.freeze
 
     def initialize(sid, instance, orgid, api_version, in_sandbox=false)
       api_version ||= SALESFORCE_API_VERSION

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -46,7 +46,6 @@ module SalesforceBulk
     def https(host)
       req = Net::HTTP.new(host, 443)
       req.use_ssl = true
-      req.verify_mode = OpenSSL::SSL::VERIFY_NONE
       req
     end
 

--- a/lib/salesforce_bulk/version.rb
+++ b/lib/salesforce_bulk/version.rb
@@ -1,3 +1,3 @@
 module SalesforceBulk
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
### Summary of Changes

- Bumped the current SFDC API version to 47.0 from 24
- Changed the gem version to 1.04 from 1.03
- Removed the verify_mode being set to VERIFY_NONE

**JIRA Link**: https://introhive.atlassian.net/browse/IHS-19694

Testing:
modify your GEM file to use the new gem

            gem 'salesforce_bulk', github: 'introhive/salesforce_bulk', branch: 'IHS-19694_salesforce_bulk_gem_completely_disables_SSL_verify_mode_2', require: false

From the console
- locate a crm details to use ( SFDC ) 

          crm_details = CrmDetails.find <id>

-  Create one of the following delayed jobs 

          Delayed::Job.enqueue(SalesforceEnqueueBulkUpdateContactsJob.new(crm_details), priority: SalesforceHelper::JOB_PRIORITIES[:enqueue_bulk_update], queue:'salesforce')

          Delayed::Job.enqueue(SalesforceEnqueueBulkUpdateLeadsJob.new(crm_details), priority: SalesforceHelper::JOB_PRIORITIES[:enqueue_bulk_update], queue:'salesforce')if crm_details.leads_enabled?

          Delayed::Job.enqueue(SalesforceBulkUpdateUsersJob.new(crm_details), priority: SalesforceHelper::JOB_PRIORITIES[:update_user_details], queue:'salesforce')

Run the delayed job and verify it didn't fail 